### PR TITLE
Add OpenResty Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ Most self-hosted software can be installed using [Docker](https://en.wikipedia.o
 
 [Apache](https://httpd.apache.org/) - Most popular web server.
 
+[OpenResty Manager](https://om.uusec.com/) - The easiest using, powerful and beautiful OpenResty Manager(Nginx Enhanced Version), open source alternative to OpenResty Edge.
+
 [Beakon](https://github.com/RealDudePerson/beakon) - A self-host location sharing webserver. Beakon aims to leak as little data as possible and uses mostly self-contained libraries and local database files. Where possible, it will reference local files and not reach out over any network. 
 
 [Caddy](https://caddyserver.com/) - The HTTP/2 Web Server with Fully Managed TLS.


### PR DESCRIPTION
Site: https://om.uusec.com/

Github: https://github.com/Safe3/openresty-manager

The easiest using, powerful and beautiful OpenResty Manager (Nginx Enhanced Version) , open source alternative to OpenResty Edge, which can enable you to easily reverse proxy your websites with security running at home or internet, including Access Control, HTTP Flood Protection, Free SSL, without having to know too much about OpenResty or Let's Encrypt.

