### PR TITLE
Add amneziawg-installer to WireGuard Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4085,6 +4085,9 @@ NetMaker Architecture. Credit: [Netmaker](https://netmaker.readthedocs.io/en/v0.
 
 [PiVPN](https://pivpn.io/) is the simplest VPN installer, designed for [Raspberry Pi](https://www.raspberrypi.com).
 
+
+[amneziawg-installer](https://github.com/bivlked/amneziawg-installer) is a one-command installer for AmneziaWG 2.0 — a WireGuard fork that bypasses DPI-based VPN blocking.
+
 [Algo VPN](https://github.com/trailofbits/algo) is a set of Ansible scripts that simplify the setup of a personal WireGuard and IPsec VPN. It uses the most secure defaults available and works with common cloud providers.
 
 [Pro Custodibus](https://www.procustodibus.com/features/) is a tool for managing WireGuard with a variety of business VPN (Virtual Private Network) use cases, such as site-to-site connectivity, secure remote access from anywhere, secure access to the cloud (Amazon Web Services, Google Cloud Platform, Microsoft Azure, etc), and more.

--- a/README.md
+++ b/README.md
@@ -4085,7 +4085,6 @@ NetMaker Architecture. Credit: [Netmaker](https://netmaker.readthedocs.io/en/v0.
 
 [PiVPN](https://pivpn.io/) is the simplest VPN installer, designed for [Raspberry Pi](https://www.raspberrypi.com).
 
-
 [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) is a one-command installer for AmneziaWG 2.0 — a WireGuard fork that bypasses DPI-based VPN blocking.
 
 [Algo VPN](https://github.com/trailofbits/algo) is a set of Ansible scripts that simplify the setup of a personal WireGuard and IPsec VPN. It uses the most secure defaults available and works with common cloud providers.


### PR DESCRIPTION
Adding amneziawg-installer to the WireGuard Tools section.\n\nAmneziaWG is a WireGuard fork that adds traffic obfuscation — helps in countries where regular WireGuard is blocked by DPI. The installer sets up the server with one command on Ubuntu/Debian.\n\nI'm the author, been running it on my own VPS. Fits next to PiVPN and Algo (similar server-side installers).